### PR TITLE
Update path to react native scripts in uninstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ But if you still want to get rid of this and revert the changes to your project,
 
 ```
 export NODE_BINARY=node
-../node_modules/react-native/packager/react-native-xcode.sh
+../node_modules/react-native/scripts/react-native-xcode.sh
 ```
 
 Then, you can revert the changes to the installed libraries by:


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
Updated readme instructions for uninstalling this package. It had the wrong path for react-native scripts. 

Before:
`../node_modules/react-native/packager/react-native-xcode.sh`

After:
`../node_modules/react-native/scripts/react-native-xcode.sh`


