### PR TITLE
xip.io-based ip address wasn’t working for me, and later releases of …

### DIFF
--- a/src/fix-script.js
+++ b/src/fix-script.js
@@ -24,6 +24,7 @@ function updateProject (project) {
 			const devConfigs = `\\"+(${configurations}${configurations.length ? '|' : ''}Debug)\\"`;
 			env.DEVELOPMENT_BUILD_CONFIGURATIONS = devConfigs;
 			env.NODE_BINARY = env.NODE_BINARY || 'node';
+			env.DISABLE_XIP = 1;
 
 			const exports = Object.keys(env)
 				.map((key) => [key, env[key]])


### PR DESCRIPTION
…react native have stopped using xip.io so this disbaled falg should probably be set

<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes



## Related issues (if any)

