### PR TITLE
Adds info to README explaining debug build configs should contain the word "Debug"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once the package is installed in your project, you just need to configure it by 
 		"postinstall": "react-native-schemes-manager all"
 	},
 	"xcodeSchemes": {
-		"Debug": ["Staging", "Preflight"],
+		"Debug": ["Staging (Debug)", "Preflight (Debug)"],
 		"Release": ["Beta"],
 		"projectDirectory": "iOS",
 		"settings": {
@@ -78,6 +78,7 @@ A good starting point for troubleshooting is:
 - Re open Xcode
 - Product -> Clean
 - Run
+- Ensure any debug configurations contain the word "Debug"
 
 If you're still having trouble, post an issue so we can look into it.
 


### PR DESCRIPTION
This is required in order for iOS app to be able to connect to metro bundler when debugging.

As you can see in `react-native-xcode.sh`, the script is looking for configuration names mentioning "Debug". If "Debug" is not in the name, it won't connect to bundler:

<img width="701" alt="Screenshot 2019-04-02 at 09 31 46" src="https://user-images.githubusercontent.com/4497624/55387883-28064e00-552a-11e9-8b84-6c5eda78676b.png">
