### PR TITLE
Support for nodenv installed via Homebrew

### DIFF
--- a/lib/react-native-xcode.sh
+++ b/lib/react-native-xcode.sh
@@ -90,6 +90,8 @@ fi
 # Set up the nodenv node version manager if present
 if [[ -x "$HOME/.nodenv/bin/nodenv" ]]; then
   eval "$("$HOME/.nodenv/bin/nodenv" init -)"
+elif [[ -x "$(command -v brew)" && -x "$(brew --prefix nodenv)/bin/nodenv" ]]; then
+  eval "$("$(brew --prefix nodenv)/bin/nodenv" init -)"
 fi
 
 [ -z "$NODE_BINARY" ] && export NODE_BINARY="node"


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes

This updates the `react-native-xcode.sh` build script to check for versions of `nodenv `installed by Homebrew. These were added to React native by https://github.com/facebook/react-native/pull/19509, this PR simply applies those same changes to `react-native-schemes-manager`'s version of the script.