### PR TITLE
fix(fix-script): format build phase command like Xcode

### DIFF
--- a/src/fix-script.js
+++ b/src/fix-script.js
@@ -36,7 +36,7 @@ function updateProject (project) {
 				runCommand,
 			];
 
-			const newScript = `"${commands.join('\\n')}"`;
+			const newScript = `"${commands.join('\\n')}\n"`;
 
 			if (step.shellScript === newScript) {
 				// It's already up to date.


### PR DESCRIPTION
## Description of changes
- Adds newline to the shell command used in build phases
- Xcode automatically formats the command, creating version control changes when used in conjunction with `react-native-schemes-manager fix-script`

## Related issues (if any)

