### PR TITLE
Optional hide lib schemes

### DIFF
--- a/lib/react-native-xcode.sh
+++ b/lib/react-native-xcode.sh
@@ -128,11 +128,6 @@ BUNDLE_FILE="$DEST/main.jsbundle"
   --assets-dest "$DEST" \
   $EXTRA_PACKAGER_ARGS
 
-# XCode randomly generates user specific workspace files whenever it feels like it.
-# We want these hidden at all times, so go ahead and clean up if they're showing now.
-cd "$SCHEMES_MANAGER_DIR/../.."
-$NODE_BINARY "$SCHEMES_MANAGER_DIR/index.js" hide-library-schemes
-
 if [[ $DEV != true && ! -f "$BUNDLE_FILE" ]]; then
   echo "error: File $BUNDLE_FILE does not exist. This must be a bug with" >&2
   echo "React Native, please report it here: https://github.com/facebook/react-native/issues"

--- a/lib/react-native-xcode.sh
+++ b/lib/react-native-xcode.sh
@@ -128,6 +128,13 @@ BUNDLE_FILE="$DEST/main.jsbundle"
   --assets-dest "$DEST" \
   $EXTRA_PACKAGER_ARGS
 
+# XCode randomly generates user specific workspace files whenever it feels like it.
+# We want these hidden at all times, so go ahead and clean up if they're showing now.
+if [[ $SKIP_HIDE_LIB_SCHEMES != true ]]; then
+  cd "$SCHEMES_MANAGER_DIR/../.."
+  $NODE_BINARY "$SCHEMES_MANAGER_DIR/index.js" hide-library-schemes
+fi
+
 if [[ $DEV != true && ! -f "$BUNDLE_FILE" ]]; then
   echo "error: File $BUNDLE_FILE does not exist. This must be a bug with" >&2
   echo "React Native, please report it here: https://github.com/facebook/react-native/issues"


### PR DESCRIPTION
## Description

Make the step hide-library-schemes optional, specifically to work around an issue it causes in uploading source maps to Sentry.

## Related issues (if any)

https://github.com/thekevinbrown/react-native-schemes-manager/issues/80
