### PR TITLE
docs(installation): add podfile project step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,17 @@ If your Xcode project is not in the default directory, "ios", you can specify th
 
 You can also pass in settings for each command. The only one currently supported is `fix-script`.
 
+At the top of the `Podfile` add the project's custom build configuration with the created schemes. This step ensures your schemes carry over the correct debug and release setups:
+
+```Ruby
+project 'YourAwesomeApp',
+  'Staging' => :debug,
+  'Preflight' => :debug,
+  'Beta' => :release
+```
+
+Run `pod install` and it should be good to go.
+
 ## What Then?
 
 The package is able to do three things:


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
A new step has been added to the installation instructions which includes the `Podfile` settings required to run custom schemes smoothly. To see more on why this should be included check out the [related issue](https://github.com/thekevinbrown/react-native-schemes-manager/issues/50).


## Related issues (if any)
https://github.com/thekevinbrown/react-native-schemes-manager/issues/50
